### PR TITLE
Remove unnecessary module.exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,6 @@ const ytdl = (link, options) => {
     return getURLsFromInfoCallback(info, options);
   });
 };
-module.exports = ytdl;
 
 ytdl.getBasicInfo = getInfo.getBasicInfo;
 ytdl.getInfo = getInfo.getInfo;


### PR DESCRIPTION
Hey @AbelTesfaye ,

I'm trying out a new use case for this package by using it inside a browser. However since it has a call to module.exports it's blowing up even after it goes through my typescript/webpack toolchain.

The module should behave exactly the same due to the export default at the bottom of the file, let me know if this is a change you would be open to accepting, if not I can keep the fork around and use that.